### PR TITLE
Improve packaging

### DIFF
--- a/cqlsh
+++ b/cqlsh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env python
 # -*- mode: Python -*-
 
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -16,21 +16,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-""":"
-# bash code here; finds a suitable python interpreter and execs this file.
-# prefer unqualified "python" if suitable:
-python -c 'import sys; sys.exit(not (0x020500b0 < sys.hexversion < 0x03000000))' 2>/dev/null \
-    && exec python "$0" "$@"
-for pyver in 2.6 2.7 2.5; do
-    which python$pyver > /dev/null 2>&1 && exec python$pyver "$0" "$@"
-done
-echo "No appropriate python interpreter found." >&2
-exit 1
-":"""
-
-from __future__ import with_statement
-
 import cmd
 import codecs
 import ConfigParser
@@ -52,7 +37,7 @@ from glob import glob
 from StringIO import StringIO
 from uuid import UUID
 
-if sys.version_info[0] != 2 or sys.version_info[1] != 7:
+if sys.version_info[:2] != (2, 7):
     sys.exit("\nCQL Shell supports only Python 2.7\n")
 
 description = "CQL Shell for Apache Cassandra"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
     url='http://git-wip-us.apache.org/repos/asf/cassandra.git',
     platforms=['any'],
     license="http://www.apache.org/licenses/LICENSE-2.0",
-    install_requires=['cql', 'simplejson', 'unittest2', 'cassandra-driver'],
+    install_requires=['cql', 'cassandra-driver'],
+    tests_require=['unittest2'],
     packages=['cqlshlib'],
     scripts = [
         'cqlsh',


### PR DESCRIPTION
- Remove the shell stuff from `cqlsh`, when installed setuptools will rewrite the shebang to be the virtualenv / system interpreter
- Remove simplejson dependency (unused)
- Remove unittest2 dependency (a test-only dependency)
