### PR TITLE
Remove unittest2 from install_requires to tests_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     platforms=['any'],
     license="http://www.apache.org/licenses/LICENSE-2.0",
     install_requires=['cql', 'simplejson', 'cassandra-driver'],
-    tests_require=['unittest2']
+    tests_require=['unittest2'],
     packages=['cqlshlib'],
     scripts = [
         'cqlsh',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
     url='http://git-wip-us.apache.org/repos/asf/cassandra.git',
     platforms=['any'],
     license="http://www.apache.org/licenses/LICENSE-2.0",
-    install_requires=['cql', 'simplejson', 'unittest2', 'cassandra-driver'],
+    install_requires=['cql', 'simplejson', 'cassandra-driver'],
+    tests_require=['unittest2']
     packages=['cqlshlib'],
     scripts = [
         'cqlsh',


### PR DESCRIPTION
Currently, we are facing failure while debian installing `cqlsh` on python 2.7.

The issue is because of traceback2->unittest2->cqlsh>=5.0.3

where:
```python
      File "/lib/python2.7/site-packages/linecache2/tests/inspect_fodder2.py", line 102
        def keyworded(*arg1, arg2=1):
                                ^
    SyntaxError: invalid syntax
```
happens on py27.

The proposed change would not install unittest2 while building the debian.